### PR TITLE
GAデフォルトではworkflow_runに複数ワークフローを指定すると依存回数分トリガーされるので、action-workflow-ru…

### DIFF
--- a/.github/workflows/create_stg_pr.yml
+++ b/.github/workflows/create_stg_pr.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - uses: ahmadnassri/action-workflow-run-wait@v1
       - name: git-pr-release
         uses: bakunyo/git-pr-release-action@master
         env:


### PR DESCRIPTION
…n-waitを使って2つ成功するまで待つ